### PR TITLE
:seedling: Remove ctx from cluster getter

### DIFF
--- a/examples/cluster-api/main.go
+++ b/examples/cluster-api/main.go
@@ -100,7 +100,7 @@ func main() {
 				log := log.FromContext(ctx).WithValues("cluster", req.ClusterName)
 				log.Info("Reconciling ConfigMap")
 
-				cl, err := mcMgr.GetCluster(ctx, req.ClusterName)
+				cl, err := mcMgr.GetCluster(req.ClusterName)
 				if err != nil {
 					return reconcile.Result{}, err
 				}

--- a/examples/kind/main.go
+++ b/examples/kind/main.go
@@ -75,7 +75,7 @@ func main() {
 				log := log.FromContext(ctx).WithValues("cluster", req.ClusterName)
 				log.Info("Reconciling ConfigMap")
 
-				cl, err := mgr.GetCluster(ctx, req.ClusterName)
+				cl, err := mgr.GetCluster(req.ClusterName)
 				if err != nil {
 					return reconcile.Result{}, err
 				}

--- a/examples/namespace/main.go
+++ b/examples/namespace/main.go
@@ -133,7 +133,7 @@ func main() {
 				log := log.FromContext(ctx).WithValues("cluster", req.ClusterName)
 				log.Info("Reconciling ConfigMap")
 
-				cl, err := mgr.GetCluster(ctx, req.ClusterName)
+				cl, err := mgr.GetCluster(req.ClusterName)
 				if err != nil {
 					return reconcile.Result{}, err
 				}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -106,7 +106,7 @@ type Manager interface {
 	// returns an existing cluster if it has been created before.
 	// If no cluster is known to the provider under the given cluster name,
 	// an error should be returned.
-	GetCluster(ctx context.Context, clusterName string) (cluster.Cluster, error)
+	GetCluster(clusterName string) (cluster.Cluster, error)
 
 	// ClusterFromContext returns the default cluster set in the context.
 	ClusterFromContext(ctx context.Context) (cluster.Cluster, error)
@@ -163,14 +163,14 @@ func WithMultiCluster(mgr manager.Manager, provider multicluster.Provider) (Mana
 // returns an existing cluster if it has been created before.
 // If no cluster is known to the provider under the given cluster name,
 // an error should be returned.
-func (m *mcManager) GetCluster(ctx context.Context, clusterName string) (cluster.Cluster, error) {
+func (m *mcManager) GetCluster(clusterName string) (cluster.Cluster, error) {
 	if clusterName == LocalCluster {
 		return m.Manager, nil
 	}
 	if m.provider == nil {
 		return nil, fmt.Errorf("no multicluster provider set, but cluster %q passed", clusterName)
 	}
-	return m.provider.Get(ctx, clusterName)
+	return m.provider.Get(clusterName)
 }
 
 // ClusterFromContext returns the default cluster set in the context.
@@ -179,7 +179,7 @@ func (m *mcManager) ClusterFromContext(ctx context.Context) (cluster.Cluster, er
 	if !ok {
 		return nil, fmt.Errorf("no cluster set in context, use ReconcilerWithCluster helper when building the controller")
 	}
-	return m.GetCluster(ctx, clusterName)
+	return m.GetCluster(clusterName)
 }
 
 // GetLocalManager returns the underlying controller-runtime manager of the host.

--- a/pkg/multicluster/aware.go
+++ b/pkg/multicluster/aware.go
@@ -54,5 +54,5 @@ type Provider interface {
 	// returns an existing cluster if it has been created before.
 	// If no cluster is known to the provider under the given cluster name,
 	// an error should be returned.
-	Get(ctx context.Context, clusterName string) (cluster.Cluster, error)
+	Get(clusterName string) (cluster.Cluster, error)
 }

--- a/providers/cluster-api/provider.go
+++ b/providers/cluster-api/provider.go
@@ -107,7 +107,7 @@ type Provider struct {
 }
 
 // Get returns the cluster with the given name, if it is known.
-func (p *Provider) Get(_ context.Context, clusterName string) (cluster.Cluster, error) {
+func (p *Provider) Get(clusterName string) (cluster.Cluster, error) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 	if cl, ok := p.clusters[clusterName]; ok {

--- a/providers/kind/provider.go
+++ b/providers/kind/provider.go
@@ -56,7 +56,7 @@ type Provider struct {
 }
 
 // Get returns the cluster with the given name, if it is known.
-func (k *Provider) Get(ctx context.Context, clusterName string) (cluster.Cluster, error) {
+func (k *Provider) Get(clusterName string) (cluster.Cluster, error) {
 	k.lock.RLock()
 	defer k.lock.RUnlock()
 	if cl, ok := k.clusters[clusterName]; ok {

--- a/providers/namespace/provider.go
+++ b/providers/namespace/provider.go
@@ -125,7 +125,7 @@ func (p *Provider) Run(ctx context.Context, mgr mcmanager.Manager) error {
 }
 
 // Get returns a cluster by name.
-func (p *Provider) Get(ctx context.Context, clusterName string) (cluster.Cluster, error) {
+func (p *Provider) Get(clusterName string) (cluster.Cluster, error) {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 	if cl, ok := p.clusters[clusterName]; ok {

--- a/providers/namespace/provider_test.go
+++ b/providers/namespace/provider_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Provider Namespace", func() {
 						log := log.FromContext(ctx).WithValues("request", req.String())
 						log.Info("Reconciling ConfigMap")
 
-						cl, err := mgr.GetCluster(ctx, req.ClusterName)
+						cl, err := mgr.GetCluster(req.ClusterName)
 						if err != nil {
 							return reconcile.Result{}, err
 						}

--- a/providers/nop/provider.go
+++ b/providers/nop/provider.go
@@ -42,6 +42,6 @@ func (p *Provider) Run(ctx context.Context, _ mcmanager.Manager) error {
 }
 
 // Get returns an error for any cluster name.
-func (p *Provider) Get(_ context.Context, clusterName string) (cluster.Cluster, error) {
+func (p *Provider) Get(clusterName string) (cluster.Cluster, error) {
 	return nil, fmt.Errorf("cluster %s not found", clusterName)
 }

--- a/providers/single/provider.go
+++ b/providers/single/provider.go
@@ -49,7 +49,7 @@ func (p *Provider) Run(ctx context.Context, _ mcmanager.Manager) error {
 }
 
 // Get returns the cluster with the given name.
-func (p *Provider) Get(_ context.Context, clusterName string) (cluster.Cluster, error) {
+func (p *Provider) Get(clusterName string) (cluster.Cluster, error) {
 	if clusterName == p.name {
 		return p.cl, nil
 	}


### PR DESCRIPTION
The context does not really make sense in this function. It is not supposed to start a cluster, but return an existing one.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->