### PR TITLE
:seedling: manager: add GetManager

### DIFF
--- a/examples/kind/go.mod
+++ b/examples/kind/go.mod
@@ -9,6 +9,7 @@ replace github.com/multicluster-runtime/multicluster-runtime/providers/kind => .
 require (
 	github.com/multicluster-runtime/multicluster-runtime v0.20.0-alpha.3
 	github.com/multicluster-runtime/multicluster-runtime/providers/kind v0.20.0-alpha.3
+	golang.org/x/sync v0.8.0
 	k8s.io/api v0.32.1
 	k8s.io/apimachinery v0.32.1
 	sigs.k8s.io/controller-runtime v0.20.1
@@ -58,7 +59,6 @@ require (
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/net v0.30.0 // indirect
 	golang.org/x/oauth2 v0.23.0 // indirect
-	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/sys v0.26.0 // indirect
 	golang.org/x/term v0.25.0 // indirect
 	golang.org/x/text v0.19.0 // indirect


### PR DESCRIPTION
We had this type assert that a multi-cluster Manager is just a Manager without embedded cluster. Let's make that explicit and add a `GetManager(ctx, clusterName) manager.Manager` func to scope it.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->