### PR TITLE
:sparkles: Add index support to providers

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - errchkjson
     - errorlint
     - exhaustive
+    - gci
     - ginkgolinter
     - goconst
     - gocritic
@@ -45,6 +46,17 @@ linters-settings:
     disable:
       - fieldalignment
       - shadow
+  gci:
+    custom-order: true
+    skip-generated: true
+    sections:
+    - standard
+    - default
+    - prefix(k8s.io)
+    - prefix(sigs.k8s.io/controller-runtime)
+    - prefix(github.com/multicluster-runtime)
+    - blank
+    - dot
   importas:
     no-unaliased: true
     alias:

--- a/Makefile
+++ b/Makefile
@@ -183,3 +183,13 @@ verify-apidiff: $(GO_APIDIFF) ## Check for API differences
 
 go-version: ## Print the go version we use to compile our binaries and images
 	@echo $(GO_VERSION)
+
+WHAT ?=
+imports:
+	@if [ -n "$(WHAT)" ]; then \
+		$(GOLANGCI_LINT) run --enable-only=gci --fix --fast $(WHAT); \
+	else \
+	  for MOD in . $$(git ls-files '**/go.mod' | sed 's,/go.mod,,'); do \
+		(cd $$MOD; $(GOLANGCI_LINT) run --enable-only=gci --fix --fast); \
+	  done; \
+	fi

--- a/examples/cluster-api/main.go
+++ b/examples/cluster-api/main.go
@@ -22,11 +22,12 @@ import (
 	"os"
 
 	"golang.org/x/sync/errgroup"
+	capiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-	capiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/examples/kind/main.go
+++ b/examples/kind/main.go
@@ -22,12 +22,13 @@ import (
 	"os"
 
 	"golang.org/x/sync/errgroup"
+
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"

--- a/hack/check-everything.sh
+++ b/hack/check-everything.sh
@@ -36,7 +36,7 @@ header_text "installing envtest tools@${ENVTEST_K8S_VERSION} with setup-envtest 
 tmp_bin=/tmp/cr-tests-bin
 (
     # don't presume to install for the user
-    GOBIN=${tmp_bin} go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+    GOBIN=${tmp_bin} go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.20
 )
 export KUBEBUILDER_ASSETS="$(${tmp_bin}/setup-envtest use --use-env -p path "${ENVTEST_K8S_VERSION}")"
 

--- a/internal/forked/testing/addr/manager_test.go
+++ b/internal/forked/testing/addr/manager_test.go
@@ -20,10 +20,10 @@ import (
 	"net"
 	"strconv"
 
+	"github.com/multicluster-runtime/multicluster-runtime/internal/forked/testing/addr"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"github.com/multicluster-runtime/multicluster-runtime/internal/forked/testing/addr"
 )
 
 var _ = Describe("SuggestAddress", func() {

--- a/pkg/builder/forked_builder_suite_test.go
+++ b/pkg/builder/forked_builder_suite_test.go
@@ -19,9 +19,6 @@ package builder
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,6 +32,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"github.com/multicluster-runtime/multicluster-runtime/internal/forked/testing/addr"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 func TestBuilder(t *testing.T) {

--- a/pkg/builder/forked_controller.go
+++ b/pkg/builder/forked_controller.go
@@ -24,18 +24,11 @@ import (
 
 	"github.com/go-logr/logr"
 
-	"sigs.k8s.io/controller-runtime/pkg/source"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 
-	mccontroller "github.com/multicluster-runtime/multicluster-runtime/pkg/controller"
-	mchandler "github.com/multicluster-runtime/multicluster-runtime/pkg/handler"
-	mcmanager "github.com/multicluster-runtime/multicluster-runtime/pkg/manager"
-	mcreconcile "github.com/multicluster-runtime/multicluster-runtime/pkg/reconcile"
-	mcsource "github.com/multicluster-runtime/multicluster-runtime/pkg/source"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
@@ -43,6 +36,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	mccontroller "github.com/multicluster-runtime/multicluster-runtime/pkg/controller"
+	mchandler "github.com/multicluster-runtime/multicluster-runtime/pkg/handler"
+	mcmanager "github.com/multicluster-runtime/multicluster-runtime/pkg/manager"
+	mcreconcile "github.com/multicluster-runtime/multicluster-runtime/pkg/reconcile"
+	mcsource "github.com/multicluster-runtime/multicluster-runtime/pkg/source"
 )
 
 // project represents other forms that we can use to

--- a/pkg/builder/forked_controller_test.go
+++ b/pkg/builder/forked_controller_test.go
@@ -23,8 +23,7 @@ import (
 	"sync/atomic"
 
 	"github.com/go-logr/logr"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,7 +33,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/ptr"
-	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -44,12 +42,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	mccontroller "github.com/multicluster-runtime/multicluster-runtime/pkg/controller"
 	mchandler "github.com/multicluster-runtime/multicluster-runtime/pkg/handler"
 	mcmanager "github.com/multicluster-runtime/multicluster-runtime/pkg/manager"
 	mcreconcile "github.com/multicluster-runtime/multicluster-runtime/pkg/reconcile"
 	mcsource "github.com/multicluster-runtime/multicluster-runtime/pkg/source"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ untypedWatchesInput = (*WatchesInput[mcreconcile.Request])(nil)

--- a/pkg/builder/forked_webhook_test.go
+++ b/pkg/builder/forked_webhook_test.go
@@ -27,8 +27,6 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,6 +38,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 const (

--- a/pkg/context/cluster.go
+++ b/pkg/context/cluster.go
@@ -19,8 +19,9 @@ package context
 import (
 	"context"
 
-	mcreconcile "github.com/multicluster-runtime/multicluster-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	mcreconcile "github.com/multicluster-runtime/multicluster-runtime/pkg/reconcile"
 )
 
 type clusterKeyType string

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	"k8s.io/client-go/util/workqueue"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/controller"

--- a/pkg/multicluster/multicluster.go
+++ b/pkg/multicluster/multicluster.go
@@ -19,6 +19,7 @@ package multicluster
 import (
 	"context"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 )
 
@@ -55,4 +56,8 @@ type Provider interface {
 	// If no cluster is known to the provider under the given cluster name,
 	// an error should be returned.
 	Get(ctx context.Context, clusterName string) (cluster.Cluster, error)
+
+	// IndexField indexes the given object by the given field on all engaged
+	// clusters, current and future.
+	IndexField(ctx context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error
 }

--- a/providers/cluster-api/provider.go
+++ b/providers/cluster-api/provider.go
@@ -23,22 +23,24 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	capiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	utilkubeconfig "sigs.k8s.io/cluster-api/util/kubeconfig"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
-	capiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	utilkubeconfig "sigs.k8s.io/cluster-api/util/kubeconfig"
+	"k8s.io/client-go/tools/clientcmd"
+
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	mcmanager "github.com/multicluster-runtime/multicluster-runtime/pkg/manager"
 	"github.com/multicluster-runtime/multicluster-runtime/pkg/multicluster"
-	"k8s.io/client-go/tools/clientcmd"
-	"sigs.k8s.io/controller-runtime/pkg/cluster"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var _ multicluster.Provider = &Provider{}

--- a/providers/cluster-api/provider.go
+++ b/providers/cluster-api/provider.go
@@ -94,6 +94,12 @@ func New(localMgr manager.Manager, opts Options) (*Provider, error) {
 	return p, nil
 }
 
+type index struct {
+	object       client.Object
+	field        string
+	extractValue client.IndexerFunc
+}
+
 // Provider is a cluster Provider that works with Cluster-API.
 type Provider struct {
 	opts   Options
@@ -104,6 +110,7 @@ type Provider struct {
 	mcMgr     mcmanager.Manager
 	clusters  map[string]cluster.Cluster
 	cancelFns map[string]context.CancelFunc
+	indexers  []index
 }
 
 // Get returns the cluster with the given name, if it is known.
@@ -189,6 +196,11 @@ func (p *Provider) Reconcile(ctx context.Context, req reconcile.Request) (reconc
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to create cluster: %w", err)
 	}
+	for _, idx := range p.indexers {
+		if err := cl.GetCache().IndexField(ctx, idx.object, idx.field, idx.extractValue); err != nil {
+			return reconcile.Result{}, fmt.Errorf("failed to index field %q: %w", idx.field, err)
+		}
+	}
 	clusterCtx, cancel := context.WithCancel(ctx)
 	go func() {
 		if err := cl.Start(clusterCtx); err != nil {
@@ -201,13 +213,13 @@ func (p *Provider) Reconcile(ctx context.Context, req reconcile.Request) (reconc
 		return reconcile.Result{}, fmt.Errorf("failed to sync cache")
 	}
 
-	// remember
+	// remember.
 	p.clusters[key] = cl
 	p.cancelFns[key] = cancel
 
 	p.log.Info("Added new cluster")
 
-	// engage manager
+	// engage manager.
 	if err := p.mcMgr.Engage(clusterCtx, key, cl); err != nil {
 		log.Error(err, "failed to engage manager")
 		delete(p.clusters, key)
@@ -216,4 +228,26 @@ func (p *Provider) Reconcile(ctx context.Context, req reconcile.Request) (reconc
 	}
 
 	return reconcile.Result{}, nil
+}
+
+// IndexField indexes a field on all clusters, existing and future.
+func (p *Provider) IndexField(ctx context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	// save for future clusters.
+	p.indexers = append(p.indexers, index{
+		object:       obj,
+		field:        field,
+		extractValue: extractValue,
+	})
+
+	// apply to existing clusters.
+	for name, cl := range p.clusters {
+		if err := cl.GetCache().IndexField(ctx, obj, field, extractValue); err != nil {
+			return fmt.Errorf("failed to index field %q on cluster %q: %w", field, name, err)
+		}
+	}
+
+	return nil
 }

--- a/providers/kind/provider.go
+++ b/providers/kind/provider.go
@@ -24,15 +24,18 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	mcmanager "github.com/multicluster-runtime/multicluster-runtime/pkg/manager"
-	"github.com/multicluster-runtime/multicluster-runtime/pkg/multicluster"
+	kind "sigs.k8s.io/kind/pkg/cluster"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/clientcmd"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	kind "sigs.k8s.io/kind/pkg/cluster"
+
+	mcmanager "github.com/multicluster-runtime/multicluster-runtime/pkg/manager"
+	"github.com/multicluster-runtime/multicluster-runtime/pkg/multicluster"
 )
 
 var _ multicluster.Provider = &Provider{}

--- a/providers/namespace/cache.go
+++ b/providers/namespace/cache.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	toolscache "k8s.io/client-go/tools/cache"
+
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )

--- a/providers/namespace/client.go
+++ b/providers/namespace/client.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/providers/namespace/cluster.go
+++ b/providers/namespace/cluster.go
@@ -25,6 +25,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	toolscache "k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
+
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"

--- a/providers/namespace/cluster.go
+++ b/providers/namespace/cluster.go
@@ -18,49 +18,13 @@ package namespace
 
 import (
 	"context"
-	"fmt"
-	"time"
 
-	apiruntime "k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	toolscache "k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 )
-
-// WithClusterNameIndex adds indexers for cluster name and namespace.
-func WithClusterNameIndex() cluster.Option {
-	return func(options *cluster.Options) {
-		old := options.Cache.NewInformer
-		options.Cache.NewInformer = func(watcher toolscache.ListerWatcher, object apiruntime.Object, duration time.Duration, indexers toolscache.Indexers) toolscache.SharedIndexInformer {
-			var inf toolscache.SharedIndexInformer
-			if old != nil {
-				inf = old(watcher, object, duration, indexers)
-			} else {
-				inf = toolscache.NewSharedIndexInformer(watcher, object, duration, indexers)
-			}
-			if err := inf.AddIndexers(toolscache.Indexers{
-				ClusterNameIndex: func(obj any) ([]string, error) {
-					o := obj.(client.Object)
-					return []string{
-						fmt.Sprintf("%s/%s", o.GetNamespace(), o.GetName()),
-						fmt.Sprintf("%s/%s", "*", o.GetName()),
-					}, nil
-				},
-				ClusterIndex: func(obj any) ([]string, error) {
-					o := obj.(client.Object)
-					return []string{o.GetNamespace()}, nil
-				},
-			}); err != nil {
-				utilruntime.HandleError(fmt.Errorf("unable to add cluster name indexers: %w", err))
-			}
-			return inf
-		}
-	}
-}
 
 // NamespacedCluster is a cluster that operates on a specific namespace.
 type NamespacedCluster struct {

--- a/providers/namespace/namespace_suite_test.go
+++ b/providers/namespace/namespace_suite_test.go
@@ -19,14 +19,15 @@ package namespace
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"k8s.io/client-go/rest"
 
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 func TestBuilder(t *testing.T) {

--- a/providers/namespace/provider_test.go
+++ b/providers/namespace/provider_test.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"errors"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"golang.org/x/sync/errgroup"
 
 	corev1 "k8s.io/api/core/v1"
@@ -42,6 +40,9 @@ import (
 	mcbuilder "github.com/multicluster-runtime/multicluster-runtime/pkg/builder"
 	mcmanager "github.com/multicluster-runtime/multicluster-runtime/pkg/manager"
 	mcreconcile "github.com/multicluster-runtime/multicluster-runtime/pkg/reconcile"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Provider Namespace", func() {

--- a/providers/nop/provider.go
+++ b/providers/nop/provider.go
@@ -20,9 +20,11 @@ import (
 	"context"
 	"fmt"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+
 	mcmanager "github.com/multicluster-runtime/multicluster-runtime/pkg/manager"
 	"github.com/multicluster-runtime/multicluster-runtime/pkg/multicluster"
-	"sigs.k8s.io/controller-runtime/pkg/cluster"
 )
 
 var _ multicluster.Provider = &Provider{}
@@ -44,4 +46,9 @@ func (p *Provider) Run(ctx context.Context, _ mcmanager.Manager) error {
 // Get returns an error for any cluster name.
 func (p *Provider) Get(_ context.Context, clusterName string) (cluster.Cluster, error) {
 	return nil, fmt.Errorf("cluster %s not found", clusterName)
+}
+
+// IndexField does nothing.
+func (p *Provider) IndexField(context.Context, client.Object, string, client.IndexerFunc) error {
+	return nil
 }

--- a/providers/single/provider.go
+++ b/providers/single/provider.go
@@ -20,9 +20,11 @@ import (
 	"context"
 	"fmt"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+
 	mcmanager "github.com/multicluster-runtime/multicluster-runtime/pkg/manager"
 	"github.com/multicluster-runtime/multicluster-runtime/pkg/multicluster"
-	"sigs.k8s.io/controller-runtime/pkg/cluster"
 )
 
 var _ multicluster.Provider = &Provider{}
@@ -54,4 +56,9 @@ func (p *Provider) Get(_ context.Context, clusterName string) (cluster.Cluster, 
 		return p.cl, nil
 	}
 	return nil, fmt.Errorf("cluster %s not found", clusterName)
+}
+
+// IndexField calls IndexField on the single cluster.
+func (p *Provider) IndexField(ctx context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error {
+	return p.cl.GetFieldIndexer().IndexField(ctx, obj, field, extractValue)
 }


### PR DESCRIPTION
A first attempt on Index support. Is this what we want?

See in particular:
1. `GetFieldIndex()` in the manager interface.
2. `IndexField()` in the provider interface.

Motivation:

Indexes must be created before cache start. They are usually uniform for multicluster controllers. Only the provider really knows how to set them up (some providers have dedicated clusters, others have one central cluster object and scoped down cluster shims on-top).

TODOs:
- [ ] add unit tests to the providers, in particular the namespace provider. This is not obvious.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->