### PR TITLE
:bug: Align go module names with directory names.

### DIFF
--- a/examples/cluster-api/go.mod
+++ b/examples/cluster-api/go.mod
@@ -1,4 +1,4 @@
-module github.com/multicluster-runtime/multicluster-runtime/examples/fleet
+module github.com/multicluster-runtime/multicluster-runtime/examples/cluster-api
 
 go 1.23.4
 

--- a/examples/kind/go.mod
+++ b/examples/kind/go.mod
@@ -1,4 +1,4 @@
-module github.com/multicluster-runtime/multicluster-runtime/examples/fleet
+module github.com/multicluster-runtime/multicluster-runtime/examples/kind
 
 go 1.23.0
 

--- a/providers/cluster-api/go.mod
+++ b/providers/cluster-api/go.mod
@@ -1,10 +1,8 @@
-module github.com/multicluster-runtime/multicluster-runtime/providers/clsuter-api
+module github.com/multicluster-runtime/multicluster-runtime/providers/cluster-api
 
 go 1.23.4
 
 replace github.com/multicluster-runtime/multicluster-runtime => ../..
-
-replace github.com/multicluster-runtime/multicluster-runtime/providers/cluster-api => ../../providers/cluster-api
 
 require (
 	github.com/go-logr/logr v1.4.2

--- a/providers/kind/go.mod
+++ b/providers/kind/go.mod
@@ -1,4 +1,4 @@
-module github.com/multicluster-runtime/multicluster-runtime/providers/fleet
+module github.com/multicluster-runtime/multicluster-runtime/providers/kind
 
 go 1.23.0
 


### PR DESCRIPTION
While evaluating this library I came across a handful of Go module names that don't align with the path they're defined in.

Another item I ran into, but didn't include in this PR, is that the `single` provider does not engage the cluster when `Run` is invoked, while other providers do. Is the intent that single cluster engagement should be done outside of the `Run` call for this provider? If not, I can either add the following patch in this PR, or a separate PR - thoughts?

```diff
diff --git a/providers/single/provider.go b/providers/single/provider.go
index c0bf01e..0da22c5 100644
--- a/providers/single/provider.go
+++ b/providers/single/provider.go
@@ -45,7 +45,12 @@ func New(name string, cl cluster.Cluster) *Provider {
 }
 
 // Run starts the provider and blocks.
-func (p *Provider) Run(ctx context.Context, _ mcmanager.Manager) error {
+func (p *Provider) Run(ctx context.Context, mgr mcmanager.Manager) error {
+       if mgr != nil {
+               if err := mgr.Engage(ctx, p.name, p.cl); err != nil {
+                       return err
+               }
+       }
        <-ctx.Done()
        return nil
 }
```

I acknowledge that this library is experimental, and would like to help however I can as it aligns well with requirements I have for multi-cluster operators.