### PR TITLE
:bug: Single cluster provider should engage the cluster when Run is called.

### DIFF
--- a/providers/kind/provider.go
+++ b/providers/kind/provider.go
@@ -152,15 +152,13 @@ func (p *Provider) Run(ctx context.Context, mgr mcmanager.Manager) error {
 			p.log.Info("Added new cluster", "cluster", clusterName)
 
 			// engage manager
-			if mgr != nil {
-				if err := mgr.Engage(clusterCtx, clusterName, cl); err != nil {
-					log.Error(err, "failed to engage manager")
-					p.lock.Lock()
-					delete(p.clusters, clusterName)
-					delete(p.cancelFns, clusterName)
-					p.lock.Unlock()
-					return false, nil
-				}
+			if err := mgr.Engage(clusterCtx, clusterName, cl); err != nil {
+				log.Error(err, "failed to engage manager")
+				p.lock.Lock()
+				delete(p.clusters, clusterName)
+				delete(p.cancelFns, clusterName)
+				p.lock.Unlock()
+				return false, nil
 			}
 		}
 

--- a/providers/single/provider.go
+++ b/providers/single/provider.go
@@ -45,7 +45,12 @@ func New(name string, cl cluster.Cluster) *Provider {
 }
 
 // Run starts the provider and blocks.
-func (p *Provider) Run(ctx context.Context, _ mcmanager.Manager) error {
+func (p *Provider) Run(ctx context.Context, mgr mcmanager.Manager) error {
+	if mgr != nil {
+		if err := mgr.Engage(ctx, p.name, p.cl); err != nil {
+			return err
+		}
+	}
 	<-ctx.Done()
 	return nil
 }

--- a/providers/single/provider.go
+++ b/providers/single/provider.go
@@ -46,10 +46,8 @@ func New(name string, cl cluster.Cluster) *Provider {
 
 // Run starts the provider and blocks.
 func (p *Provider) Run(ctx context.Context, mgr mcmanager.Manager) error {
-	if mgr != nil {
-		if err := mgr.Engage(ctx, p.name, p.cl); err != nil {
-			return err
-		}
+	if err := mgr.Engage(ctx, p.name, p.cl); err != nil {
+		return err
 	}
 	<-ctx.Done()
 	return nil


### PR DESCRIPTION
This PR builds on top of the module name changes in https://github.com/multicluster-runtime/multicluster-runtime/pull/17 and corrects a bug identified while making those changes.

See https://github.com/multicluster-runtime/multicluster-runtime/pull/17#issuecomment-2720292165 for the recommendation to open a separate PR for the fix.

I have the `mgr != nil` check in place due to seeing that in the kind provider, and to some degree the cluster-api provider. The namespace provider does not seem to perform this check.